### PR TITLE
app menu is too tall on small screens

### DIFF
--- a/src/components/headers/AppMenu.js
+++ b/src/components/headers/AppMenu.js
@@ -50,7 +50,7 @@ const StickyWrapper = styled.div`
   z-index: ${(props) => (props.drawerIsOpen ? 0 : 2)};
 
   @media only screen and (max-width: ${MEDIA_QUERY_MD}px) {
-    height: 312px;
+    height: 120px;
   }
 `;
 


### PR DESCRIPTION
Before:
![staging openlattice com_old](https://user-images.githubusercontent.com/440299/80780911-70c17980-8b25-11ea-906c-f5d9f57c13a4.png)

After:
![staging openlattice com](https://user-images.githubusercontent.com/440299/80780918-761ec400-8b25-11ea-8121-20b831a273d8.png)
